### PR TITLE
Fixed provider template not being added to providers if approved

### DIFF
--- a/src/lib/pages/admin/resources-list.component.ts
+++ b/src/lib/pages/admin/resources-list.component.ts
@@ -328,7 +328,7 @@ export class ResourcesListComponent implements OnInit {
       () => {
         this.providers.forEach(
           p => {
-            if (p.templateStatus === 'pending template') {
+            if (p.templateStatus === 'pending template' || p.templateStatus === 'approved template') {
               this.resourceService.getResourceTemplateOfProvider(p.id).subscribe(
                 res => {
                   if (res) {

--- a/src/lib/services/service-extensions.service.ts
+++ b/src/lib/services/service-extensions.service.ts
@@ -62,9 +62,11 @@ export class ServiceExtensionsService {
 
   getMonitoringStatus(serviceId: string, showAllStatuses?: boolean) {
     serviceId = decodeURIComponent(serviceId);
-    if (showAllStatuses) return this.http.get<MonitoringStatus[]>(this.base + `/service-extensions/monitoring/monitoringStatus/${serviceId}?allStatuses=true`, this.options);
-      return null
-    // return this.http.get<MonitoringStatus[]>(this.base + `/service-extensions/monitoring/monitoringStatus/${serviceId}`, this.options); //current status
+    if (showAllStatuses) {
+      return this.http.get<MonitoringStatus[]>(this.base + `/service-extensions/monitoring/monitoringStatus/${serviceId}?allStatuses=true`, this.options);
+    } else {
+      return this.http.get<MonitoringStatus[]>(this.base + `/service-extensions/monitoring/monitoringStatus/${serviceId}`, this.options); //current status
+    }
   }
 
   getMonitoringAvailability(serviceId: string) {


### PR DESCRIPTION
This fixes being unable to activate services if the provider is approved.

This PR also fixes `getMonitoringStatus()` returning `null` when `showAllStatuses` was not `true`.